### PR TITLE
Add support for oneOf, anyOf, allOf, and not

### DIFF
--- a/OpenApiDocumentModifier.cs
+++ b/OpenApiDocumentModifier.cs
@@ -97,16 +97,16 @@ public static class OpenApiDocumentModifier
             ProcessPropertiesIfNew(schema.Items, rootSchemas);
         else
         {
-            if (schema is { AllOf.Count: > 0 })
-                foreach (var subschema in schema.AllOf)
+            if (schema is { AllOf: not null })
+                foreach (var subschema in schema.AllOf.Where(s => s.Reference is not null))
                     ProcessPropertiesIfNew(subschema, rootSchemas);
 
-            if (schema is { OneOf.Count: > 0 })
-                foreach (var subschema in schema.OneOf)
+            if (schema is { OneOf: not null })
+                foreach (var subschema in schema.OneOf.Where(s => s.Reference is not null))
                     ProcessPropertiesIfNew(subschema, rootSchemas);
 
-            if (schema is { AnyOf.Count: > 0 })
-                foreach (var subschema in schema.AnyOf)
+            if (schema is { AnyOf: not null })
+                foreach (var subschema in schema.AnyOf.Where(s => s.Reference is not null))
                     ProcessPropertiesIfNew(subschema, rootSchemas);
 
             if (schema is { Not.Reference: not null })


### PR DESCRIPTION
In its current state, the tool produces an invalid OpenAPI specification when the source specification contains schemas referenced via the `oneOf`, `anyOf`, `allOf`, or `not` keywords. In such cases, those schemas are shaken off, and their definitions are missing in the resulting specification.

This PR adds support for source specifications containing the above keywords.

Thank you for the tool; it has been helpful. :)